### PR TITLE
Use wiringPi's SPI library to access LoRa transmitter

### DIFF
--- a/RHWirePiSPI.cpp
+++ b/RHWirePiSPI.cpp
@@ -1,0 +1,116 @@
+#include <RHWirePiSPI.h>
+#include <wiringPi.h>
+#include <wiringPiSPI.h>
+
+typedef unsigned char byte;
+
+void RHWirePiSPI::selectSlave()
+{
+    digitalWrite(_slaveSelectPin, LOW);
+}
+
+void RHWirePiSPI::unselectSlave()
+{
+    digitalWrite(_slaveSelectPin, HIGH);
+}
+
+uint8_t RHWirePiSPI::spiRead(uint8_t reg)
+{
+    byte spibuf[2];
+
+    selectSlave();
+    spibuf[0] = reg & 0x7F;
+    spibuf[1] = 0x00;
+    wiringPiSPIDataRW(_spiChannel, spibuf, 2);
+    unselectSlave();
+
+    return spibuf[1];
+}
+
+uint8_t RHWirePiSPI::spiWrite(uint8_t reg, uint8_t value)
+{
+    byte spibuf[2];
+
+    spibuf[0] = reg | 0x80;
+    spibuf[1] = value;
+    selectSlave();
+    wiringPiSPIDataRW(_spiChannel, spibuf, 2);
+
+    unselectSlave();
+
+    return spibuf[0];
+}
+
+
+RHWirePiSPI::RHWirePiSPI(uint8_t slaveSelectPin, uint8_t spiChannel)
+    : 
+    _slaveSelectPin(slaveSelectPin),
+    _spiChannel(spiChannel)
+{
+}
+
+
+bool RHWirePiSPI::init()
+{
+    // Initialise the slave select pin
+    pinMode(_slaveSelectPin, OUTPUT);
+    digitalWrite(_slaveSelectPin, HIGH);
+
+    wiringPiSPISetup(_spiChannel, 500000);
+    delay(100);
+    return true;
+}
+
+
+uint8_t RHWirePiSPI::spiBurstRead(uint8_t reg, uint8_t* dest, uint8_t len)
+{
+    uint8_t status = 0;
+    ATOMIC_BLOCK_START;
+    selectSlave();
+    byte spibuf[1];
+    spibuf[0] = reg & 0x7F; // Send the start address with the write mask off
+    wiringPiSPIDataRW(_spiChannel, spibuf, 1); 
+    status = spibuf[0];
+    wiringPiSPIDataRW(_spiChannel, dest, len); 
+    unselectSlave();
+    ATOMIC_BLOCK_END;
+    return status;
+}
+
+uint8_t RHWirePiSPI::spiBurstWrite(uint8_t reg, const uint8_t* src, uint8_t len)
+{
+    uint8_t status = 0;
+    ATOMIC_BLOCK_START;
+    selectSlave();
+    byte spibuf[1];
+    spibuf[0] = reg | 0x80; // Send the start address with the write mask on
+    wiringPiSPIDataRW(_spiChannel, spibuf, 1); 
+    status = spibuf[0];
+
+    while (len--) {
+        spibuf[0] = *src++;
+        wiringPiSPIDataRW(_spiChannel, spibuf, 1); 
+    }
+    unselectSlave();
+    ATOMIC_BLOCK_END;
+    return status;
+}
+
+void RHWirePiSPI::attachInterrupt(uint8_t gpio, void (*function)(void), int mode)
+{
+#ifdef RH_LINUX_SPI_DEBUG
+	printf("RHLinuxSPI::attachInterrupt() : gpio=%d mode=%d\n", gpio, mode);
+#endif
+	pinMode(gpio, INPUT);
+	if( wiringPiISR(gpio, mode, function) < 0 ){
+		printf("RHLinuxSPI::attachInterrupt() : wiringPiIsr isr failed!\n");
+	}
+}
+
+void RHWirePiSPI::detachInterrupt(uint8_t gpio, void (*function)(void))
+{
+#ifdef RH_LINUX_SPI_DEBUG
+	printf("RHLinuxSPI::detachInterrupt()\n");
+#endif
+}
+

--- a/RHWirePiSPI.h
+++ b/RHWirePiSPI.h
@@ -1,0 +1,77 @@
+// RHWirePiSPI.h
+// Author: Joel Kozikowski
+
+#ifndef RHWirePiSPI_h
+#define RHWirePiSPI_h
+
+#include <RHGenericDriver.h>
+
+// This is the bit in the SPI address that marks it as a write
+#define RH_SPI_WRITE_MASK 0x80
+
+class RHGenericSPI;
+
+/////////////////////////////////////////////////////////////////////
+/// \class RHWirePiSPI RHWirePiSPI.h <RHWirePiSPI.h>
+/// \brief Base class for a RadioHead driver that uses WiringPi and
+/// its SPI library to access the SPI bus to communicate with its transport hardware.
+///
+class RHWirePiSPI : public RHGenericDriver
+{
+public:
+    /// Constructor
+    /// \param[in] slaveSelectPin The controler pin to use to select the desired SPI device. This pin will be driven LOW
+    /// during SPI communications with the SPI device that uis iused by this Driver. Pin numbers
+    /// are in "wiringPi" format (e.g. default slave select (aka CE0) is 10, which is pin 24 on
+    /// the 40 pin header)
+    RHWirePiSPI(uint8_t slaveSelectPin = 10, uint8_t spiChannel = 0);
+
+
+    /// Initialise the Driver transport hardware and software.
+    /// Make sure the Driver is properly configured before calling init().
+    /// \return true if initialisation succeeded.
+    bool init();
+
+    /// Reads a single register from the SPI device
+    /// \param[in] reg Register number
+    /// \return The value of the register
+    uint8_t  spiRead(uint8_t reg);
+
+    /// Writes a single byte to the SPI device
+    /// \param[in] reg Register number
+    /// \param[in] val The value to write
+    /// \return Some devices return a status byte during the first data transfer. This byte is returned.
+    ///  it may or may not be meaningfule depending on the the type of device being accessed.
+    uint8_t spiWrite(uint8_t reg, uint8_t val);
+
+    /// Reads a number of consecutive registers from the SPI device using burst read mode
+    /// \param[in] reg Register number of the first register
+    /// \param[in] dest Array to write the register values to. Must be at least len bytes
+    /// \param[in] len Number of bytes to read
+    /// \return Some devices return a status byte during the first data transfer. This byte is returned.
+    ///  it may or may not be meaningfule depending on the the type of device being accessed.
+    uint8_t spiBurstRead(uint8_t reg, uint8_t* dest, uint8_t len);
+
+    /// Write a number of consecutive registers using burst write mode
+    /// \param[in] reg Register number of the first register
+    /// \param[in] src Array of new register values to write. Must be at least len bytes
+    /// \param[in] len Number of bytes to write
+    /// \return Some devices return a status byte during the first data transfer. This byte is returned.
+    ///  it may or may not be meaningfule depending on the the type of device being accessed.
+    uint8_t spiBurstWrite(uint8_t reg, const uint8_t* src, uint8_t len);
+
+
+    void attachInterrupt(uint8_t gpio, void (*function)(void), int mode);
+    void detachInterrupt(uint8_t gpio, void (*function)(void));
+    
+private:
+   void selectSlave();
+   void unselectSlave();
+protected:
+    /// The pin number of the Slave Selct pin that is used to select the desired device.
+    uint8_t             _slaveSelectPin;
+    uint8_t             _spiChannel;
+
+};
+
+#endif

--- a/RH_RF95.h
+++ b/RH_RF95.h
@@ -14,7 +14,7 @@
 
 #if (RH_PLATFORM == RH_PLATFORM_RPI)
 #include <RHGenericDriver.h>
-#include <RHLinuxSPI.h>
+#include <RHWirePiSPI.h>
 #else
 #include <RHSPIDriver.h>
 #endif
@@ -404,7 +404,7 @@
 /// (Caution: we dont claim laboratory accuracy for these measurements)
 /// You would not expect to get anywhere near these powers to air with a simple 1/4 wavelength wire antenna.
 #if (RH_PLATFORM == RH_PLATFORM_RPI)
-class RH_RF95 : public RHGenericDriver, public RHLinuxSPI
+class RH_RF95 : public RHWirePiSPI
 #else
 class RH_RF95 : public RHSPIDriver
 #endif
@@ -458,7 +458,7 @@ public:
     /// \param[in] spi Pointer to the SPI interface object to use. 
     ///                Defaults to the standard Arduino hardware SPI interface
 #if (RH_PLATFORM == RH_PLATFORM_RPI)
-    RH_RF95(uint8_t slaveSelectPin = 253, uint8_t interruptPin = 4);
+    RH_RF95(uint8_t slaveSelectPin = 25, uint8_t interruptPin = 4, uint8_t resetPin = 17, uint8_t spiChannel = 0);
 #else
     RH_RF95(uint8_t slaveSelectPin = SS, uint8_t interruptPin = 2, RHGenericSPI& spi = hardware_spi);
 #endif
@@ -602,6 +602,10 @@ private:
 
     /// True when there is a valid message in the buffer
     volatile bool       _rxBufValid;
+
+    // Used by Raspberry Pi Dragino HAT
+    uint8_t _resetPin;
+    int _initCalled = 0;
 };
 
 /// @example rf95_client.pde


### PR DESCRIPTION
This PR enables use of the Dragino LoRa HAT (and possibly other SX1276 radios) on a Raspberry Pi.  By changing to the WiringPi library for SPI vs. Linux SPI, these changes honor pin configurations passed in to the new constructor of the RH_RF95 class.

These code modifications were inspired by the SPI code that I found was working with the Dragino HAT from this project: https://github.com/tftelkamp/single_chan_pkt_fwd
